### PR TITLE
the current cljs build config in the project.clj seems to be deprecated so I have made the fix

### DIFF
--- a/src/leiningen/new/cljs_exnihilo/project.clj
+++ b/src/leiningen/new/cljs_exnihilo/project.clj
@@ -4,21 +4,21 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                            [org.clojure/clojurescript "0.0-1806"]
-                            [compojure "1.1.5"]
-                            [jayq "2.4.0"]
-                            [hiccup "1.0.4"]]
+                 [org.clojure/clojurescript "0.0-1806"]
+                 [compojure "1.1.5"]
+                 [jayq "2.4.0"]
+                 [hiccup "1.0.4"]
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]]
   :source-paths ["src/clj"]
   :plugins [[lein-cljsbuild "0.3.2"]
                  [lein-ring "0.8.7"]]
-  :cljsbuild {
-    :builds {
-             :main {
-                        :source-path "src/cljs"
-                        :compiler {
-                                     :output-to "resources/public/js/cljs.js"
-                                     :optimizations :simple
-                                     :pretty-print true}}}}
+
+  :cljsbuild
+    {:builds [{:source-paths ["src/cljs"],
+               :id "main",
+               :compiler {:optimizations :simple,
+                          :output-to "resources/public/js/cljs.js",
+                          :pretty-print true}}]}
   :main {{name}}.server
   :ring {:handler {{name}}.server/app})
 


### PR DESCRIPTION
Hi, jtfmumm. I'm a newbie to clojurescript dev. I saw your blog on getting started with clojurescript. I thought the tutorial was great so used your cljs-exnihilo to create new clojurescript projects with leiningen. When I typed lein cljsbuild auto soon I got the following messsage:

WARNING: your :cljsbuild configuration is in a deprecated format.  It has been
automatically converted it to the new format, which will be printed below.
## It is recommended that you update your :cljsbuild configuration ASAP.

:cljsbuild
{:builds
 [{:source-paths ["src/cljs"],
   :id "main",
   :compiler
   {:optimizations :simple,
    :output-to "resources/public/js/cljs.js",
##     :pretty-print true}}]}

See https://github.com/emezeske/lein-cljsbuild/blob/master/README.md
## for details on the new format.

I have made the fix. Tell me what ya think. Thanks

Ariaroo Efe,
Lagos, Nigeria. 
